### PR TITLE
Add class scrollable instead of replacing

### DIFF
--- a/src/timelines.js
+++ b/src/timelines.js
@@ -503,7 +503,7 @@ var timelines = function() {
 				.on("zoom", move);
 
 			gParent
-				.attr("class", "scrollable")
+				.classed("scrollable", true)
 				.call(zoom);
 
 			if (! allowZoom) {


### PR DESCRIPTION
If the class scrollable replaces all existing classes, things will break.

I think adding the class would be wiser.