### PR TITLE
hoist xScale and xAxis variable to top level fn.

### DIFF
--- a/src/timelines.js
+++ b/src/timelines.js
@@ -62,7 +62,9 @@ var timelines = function() {
 				showAxisHeaderBackground = false,
 				showAxisNav = false,
 				showAxisCalendarYear = false,
-				xAxisClass = 'timeline-xAxis'
+				xAxisClass = 'timeline-xAxis',			
+		    		xScale = null,
+				xAxis = null
 			;
 
 		var appendTimeAxis = function(g, xAxis, yPosition) {
@@ -277,8 +279,6 @@ var timelines = function() {
 					return output;
 			};
 
-			var xScale;
-			var xAxis;
 			if (orient == "bottom") {
 				xAxis = axisBottom();
 			} else if (orient == "top") {


### PR DESCRIPTION
Without this hoist on label click (when in strict mode) can result in xScale being undefined in the click handler and thus causing a runtime exception.