### PR TITLE
Added function to sets a custom time to be used by showToday function

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,10 @@ Takes in no arguments. Toggles a vertical line showing the current Date.now() ti
 
 Sets the formatting of the showToday line. Color cycle can also be of the format `rgb(x, y, z)`.
 
+### .setTodayDate(date)
+
+Sets a custom time to be used by showToday function like current time.
+
 ### .showBorderLine()
 
 Takes in no arguments. Toggles a vertical line showing the borders of one specific timeline. Uses showBorderFormat for the line formatting.

--- a/src/timelines.js
+++ b/src/timelines.js
@@ -52,6 +52,7 @@ var timelines = function() {
 				navMargin = 60,
 				showTimeAxis = true,
 				showAxisTop = false,
+				todayDate = 0,
 				showTodayLine = false,
 				timeAxisTick = false,
 				timeAxisTickFormat = {stroke: "stroke-dasharray", spacing: "4 10"},
@@ -543,7 +544,9 @@ var timelines = function() {
 			}
 
 			if (showTodayLine) {
-				var todayLine = xScale(new Date());
+				var today = new Date().getTime();
+				if (todayDate) { today = todayDate; }
+				var todayLine = xScale(new Date(today));
 				appendLine(todayLine, showTodayFormat);
 			}
 
@@ -819,6 +822,12 @@ var timelines = function() {
 			showTodayFormat = todayFormat;
 			return timelines;
 		};
+
+		timelines.setTodayDate = function(date) {
+			if (!arguments.length) return todayDate;
+			todayDate = date;
+			return timelines;
+		}
 
 		timelines.colorProperty = function(colorProp) {
 			if (!arguments.length) return colorPropertyName;


### PR DESCRIPTION
Hello how are you?
I would like to make a code improvement suggestion as I develop a project using the d3 timeline, but I need to set a custom date to use with the showToday () function. I made the necessary code modification just to add the feature without interfering with the rest of the code. If you could accept the change in your repository and update your package at https://www.npmjs.com/package/d3-timelines, it would be of great help. Can you help me? Thanks in advance!